### PR TITLE
[RMA-4264] Support Rails <5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pg_audit_log
 
-NOTE: this repo is a fork of https://github.com/dylanz/pg_audit_log. The original Gem was on Github at casecommons/pg_audit_log, but it has since been taken down. This fork has been maintained only to the extent that it has been updated to be compatible with Rails <5.2.
+NOTE: this repo is a fork of https://github.com/dylanz/pg_audit_log. The original Gem was on Github at casecommons/pg_audit_log, but it has since been taken down. This fork has been maintained only to the extent that it has been updated to be compatible with Rails <5.3.
 
 ## Description
 
@@ -51,7 +51,7 @@ On a 2.93GHz i7 with PostgreSQL 9.1 the audit log has an overhead of about 0.003
 
 - ActiveRecord
 - PostgreSQL
-- Rails 3.2, 4.x, <5.2
+- Rails 3.2, 4.x, <5.3
 
 ## LICENSE
 

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 4.2', '< 5.2'
+  spec.add_dependency 'rails', '>= 4.2', '< 5.3'
   spec.add_dependency 'pg', '>= 0.9.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
### Overview
I updated the gemspecs and docs to support up to rails <5.3. No CI, but passed the tests locally following these steps

* Ran `'CREATE DATABASE pg_audit_log_test;' -U postgres` (first time i had worked on this repo)
* Set my env var to the appropriate rails version`export RAILS_VERSION=5.2.4.3`
* `bundle update rails`
* Confirmed in the lockfile that the right version is being used
* `rake spec`

A few questions, that may be out of scope here:
* Is there a reason the Gemfile.lock is gitignored? Maybe we actually want to check it into VC?
* There's a travis.yml file for travis CI, we dont use travis and the config has become stale. Should I rm it?

### Testing
Deployed to staging with pg_audit_log pointed at this branch. Clicked around and confirmed my activity ended up in the audit log
```SQL
SELECT * FROM audit_log_202007
ORDER BY occurred_at DESC
LIMIT 10;
```
saw login, editing my user info, creating an encounter

### Deployment Plan
After this is merged on the RMA run `bundle update pg_audit_log`, commit and push the changes to the lockfile.