### PR TITLE
Add internal_exec_query method

### DIFF
--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -45,6 +45,11 @@ module PGAuditExtensions
     super(*args, **kwargs, &block)
   end
 
+  def internal_exec_query(*args, **kwargs, &block)
+    set_audit_user_id_and_name
+    super(*args, **kwargs, &block)
+  end
+
   def exec_update(*args, &block)
     set_audit_user_id_and_name
     super(*args, &block)


### PR DESCRIPTION
Basically, active record in 7.0.8 was using exec_query here:
https://github.com/rails/rails/blob/v7.0.8.7/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L560
And in 7.1 it's internal_exec_query  and we don't have an override for it.
https://github.com/rails/rails/blob/v7.1.5.1/activerecord/lib/active_record/connection_adapters/abstract/database_statements.rb#L630
So we need to add another method to lib/pg_audit_log/extensions/postgresql_adapter.rb