### PR TITLE
Add symbol argument support to `rename_table`

### DIFF
--- a/lib/pg_audit_log/extensions/postgresql_adapter.rb
+++ b/lib/pg_audit_log/extensions/postgresql_adapter.rb
@@ -19,6 +19,9 @@ module PGAuditExtensions
   end
 
   def rename_table(table_name, new_name)
+    table_name = table_name.to_s
+    new_name = new_name.to_s
+
     if PgAuditLog::Triggers.tables_with_triggers.include?(table_name)
       PgAuditLog::Triggers.drop_for_table(table_name)
     end

--- a/spec/pg_audit_log_spec.rb
+++ b/spec/pg_audit_log_spec.rb
@@ -440,7 +440,19 @@ describe PgAuditLog do
           expect(trigger_names).not_to include('audit_ignored_table')
           expect(trigger_names).not_to include("audit_#{new_table_name}")
           expect(PgAuditLog::Triggers.tables_with_triggers).not_to include(new_table_name)
+          connection.drop_table(new_table_name) rescue nil
+        end
+      end
 
+      context 'when symbols are passed in as table names' do
+        it "should automatically drop and create the trigger" do
+          new_table_name = "new_table_#{Time.current.to_i}"
+          connection.create_table('test_table')
+          connection.rename_table(:test_table, new_table_name)
+
+          expect(trigger_names).not_to include('audit_test_table')
+          expect(trigger_names).to include("audit_#{new_table_name}")
+          expect(PgAuditLog::Triggers.tables_with_triggers).to include(new_table_name)
           connection.drop_table(new_table_name) rescue nil
         end
       end

--- a/spec/pg_audit_log_spec.rb
+++ b/spec/pg_audit_log_spec.rb
@@ -448,7 +448,7 @@ describe PgAuditLog do
         it "should automatically drop and create the trigger" do
           new_table_name = "new_table_#{Time.current.to_i}"
           connection.create_table('test_table')
-          connection.rename_table(:test_table, new_table_name)
+          connection.rename_table(:test_table, new_table_name.to_sym)
 
           expect(trigger_names).not_to include('audit_test_table')
           expect(trigger_names).to include("audit_#{new_table_name}")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
   config.before(:each) do
     PgAuditLog::Entry.uninstall rescue nil
     connection.tables.each do |table|
-      connection.drop_table_without_auditing(table)
+      connection.execute("DROP TABLE #{table}")
     end
     PgAuditLog::Triggers.uninstall rescue nil
     PgAuditLog::Entry.uninstall


### PR DESCRIPTION
While working on [renaming enrollments to legacy_enrollments](https://fcm.atlassian.net/browse/FCM-8065), I noticed a subtle bug with the way `online_migrations` and `pg_audit_log` behave together. When I rolled back [this migration](https://github.com/footholdtech/rma/blob/fcm-8065-replace-enrollments-with-legacy-enrollments/db/migrate/20250603185132_initialize_rename_enrollments_to_legacy_enrollments.rb), I was still seeing an audit trigger named `audit_legacy_enrollments` (albeit pointing to the `enrollments` table), even though the original trigger was named `audit_enrollments`. After digging in, I noticed that when `rename_table` ([pg_audit_log](https://github.com/footholdtech/pg_audit_log/blob/main/lib/pg_audit_log/extensions/postgresql_adapter.rb#L21), [online_migrations](https://github.com/fatkodima/online_migrations/blob/be734a4b9fef435e288539d555da18f12cb6af63/lib/online_migrations/schema_statements.rb#L346)) is called in the context of `initialize_table_rename`, the first argument ends up becoming a symbol, while it's normally a string (weirdly, even when the migration itself specifies it as a symbol...). TBH I can't find where the original symbols would be converted to strings, but since the original API accepts both symbols and strings, I think it makes sense for `pg_audit_log` to be defensive here and accept both.

To test this, I added a spec case to exercise what I observed around the rollback behavior locally. Locally, I also pointed my development branch to this branch and confirmed that rolling back no longer leads to a diff between the original DB state and the rolled back DB state.