### PR TITLE
[FCM-8671] Rails 8 update

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -11,5 +11,9 @@ appraise 'rails-7-2' do
 end
 
 appraise 'rails-8-0' do
-  gem 'rails', '~> 8.0'
+  gem 'rails', '~> 8.0.0'
+end
+
+appraise 'rails-8-1' do
+  gem 'rails', '~> 8.1.0'
 end

--- a/README.md
+++ b/README.md
@@ -84,3 +84,34 @@ On a 2.93GHz i7 with PostgreSQL 9.1 the audit log has an overhead of about 0.003
 ## LICENSE
 
 Copyright © 2010–2014 Case Commons, LLC. Licensed under the MIT license, available in the “LICENSE” file.
+
+# FCM Annotations
+
+> Added during the Rails 8 upgrade (FCM-8671). Everything above is the upstream README,
+> kept as-is; the notes below reflect how we develop and test this fork locally.
+
+## Local test database & specs
+
+### Requirements
+
+- **PostgreSQL** — a running server is required (currently validated against 17.4). Install it via Homebrew (`brew install postgresql@17`) or another tool, and start it before setting up the database.
+- **Ruby** — developed against 3.3.11.
+
+### Set up the test database
+
+Rake tasks are provided so you don't have to run raw SQL:
+
+```console
+$ bundle install
+$ bundle exec rake db:setup      # create pg_audit_log_test + install the audit_log schema
+```
+
+Lower-level tasks are also available: `db:create`, `db:migrate`, `db:drop`, `db:reset`. This gem has no versioned migrations — its schema is the `audit_log` table plus the audit functions — so `db:migrate` just installs those, and there is no rollback task. The connection reads the same environment variables that upstream `spec/spec_helper.rb` already uses — `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` (all optional; anything unset falls back to the local socket and your OS user). The database name is `pg_audit_log_test`, hardcoded in `spec_helper.rb`. Because the task and the specs read the same variables, a single `DB_USER=… DB_PASSWORD=…` applies to both. (`createdb pg_audit_log_test` also works — the suite installs the schema itself on each run.)
+
+### Run the specs
+
+```console
+$ bundle exec rspec
+```
+
+No fixtures or seed data are needed (or shipped): the suite uses [`with_model`](https://github.com/Casecommons/with_model) to define throwaway tables per example and reinstalls the audit schema on each run.

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 
+# Load database tasks (db:create, db:migrate, db:setup, db:reset, db:drop).
+Dir.glob(File.expand_path('tasks/*.rake', __dir__)).sort.each { |task_file| load task_file }
+
 desc 'Run specs'
 RSpec::Core::RakeTask.new
 

--- a/gemfiles/rails_8_1.gemfile
+++ b/gemfiles/rails_8_1.gemfile
@@ -2,6 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 8.0.0"
+gem "rails", "~> 8.1.0"
 
 gemspec path: "../"

--- a/pg_audit_log.gemspec
+++ b/pg_audit_log.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails', '>= 7.0', '<= 8.0'
+  spec.add_dependency 'rails', '>= 7.0', '< 8.2'
   spec.add_dependency 'pg', '>= 0.9.0'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'debug'

--- a/tasks/db.rake
+++ b/tasks/db.rake
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+#
+# Minimal, Rails-like database tasks for pg_audit_log's OWN test database.
+#
+# This gem ships no versioned migration files -- its "schema" is the `audit_log`
+# table plus the audit trigger/function, which are installed programmatically.
+# So `db:migrate` here simply installs that schema; there are no step-by-step
+# migrations and therefore no rollback task. Tear down with `db:drop`.
+#
+# Connection settings intentionally mirror the upstream spec/spec_helper.rb so a
+# single set of env vars works for both `rake db:*` and the specs. spec_helper.rb
+# reads these (all optional; anything unset falls back to libpq defaults — the
+# local socket + current OS user):
+#   DB_HOST, DB_PORT, DB_USER, DB_PASSWORD
+# The database name is pg_audit_log_test (hardcoded in spec_helper.rb).
+#
+# Usage:
+#   bundle exec rake db:setup    # create the database + install the schema
+#   bundle exec rake db:create   # create the pg_audit_log_test database only
+#   bundle exec rake db:migrate  # install the audit_log table + functions only
+#   bundle exec rake db:reset    # drop + create + migrate
+#   bundle exec rake db:drop     # tear the database down
+
+def pg_audit_log_test_database
+  # Hardcoded in spec/spec_helper.rb; kept identical here on purpose.
+  "pg_audit_log_test"
+end
+
+def pg_audit_log_db_config(database)
+  {
+    adapter:      "postgresql",
+    database:     database,
+    host:         ENV.fetch("DB_HOST", nil),
+    port:         ENV.fetch("DB_PORT", nil),
+    user:         ENV.fetch("DB_USER", nil),
+    password:     ENV.fetch("DB_PASSWORD", nil),
+    min_messages: "warning"
+  }
+end
+
+# CREATE DATABASE / DROP DATABASE cannot run from inside the target database, so
+# connect to the "postgres" maintenance database for those operations.
+def pg_audit_log_on_maintenance_db
+  require "pg_audit_log"
+  ActiveRecord::Base.establish_connection(pg_audit_log_db_config("postgres"))
+  yield ActiveRecord::Base.connection
+ensure
+  ActiveRecord::Base.connection_pool.disconnect! if ActiveRecord::Base.connected?
+end
+
+namespace :db do
+  desc "Create the pg_audit_log_test database"
+  task :create do
+    pg_audit_log_on_maintenance_db do |connection|
+      connection.create_database(pg_audit_log_test_database)
+      puts "Created database '#{pg_audit_log_test_database}'."
+    end
+  rescue ActiveRecord::StatementInvalid => e
+    raise unless e.cause.is_a?(PG::DuplicateDatabase)
+
+    puts "Database '#{pg_audit_log_test_database}' already exists; skipping."
+  end
+
+  desc "Drop the pg_audit_log_test database"
+  task :drop do
+    pg_audit_log_on_maintenance_db do |connection|
+      connection.drop_database(pg_audit_log_test_database)
+      puts "Dropped database '#{pg_audit_log_test_database}'."
+    end
+  end
+
+  desc "Install the audit_log table + functions (no versioned migrations exist)"
+  task :migrate do
+    require "pg_audit_log"
+    ActiveRecord::Base.establish_connection(pg_audit_log_db_config(pg_audit_log_test_database))
+    PgAuditLog::Entry.install unless PgAuditLog::Entry.installed?
+    PgAuditLog::Function.install
+    puts "Installed audit_log schema into '#{pg_audit_log_test_database}'."
+  end
+
+  desc "Create the database and install the schema"
+  task setup: %i[create migrate]
+
+  desc "Drop, recreate, and reinstall the schema"
+  task reset: %i[drop create migrate]
+end


### PR DESCRIPTION
## Overview / Approach

Upgraded Rails support to 8.0 and 8.1, updated `gemspec` dependencies, add database tasks

## Testing

This gem's own specs fully pass:

```bash
>> BUNDLE_GEMFILE=/Users/arman/Work/pg_audit_log/gemfiles/rails_7_0.gemfile bundle exec rake
/Users/arman/.asdf/installs/ruby/3.3.11/bin/ruby -I/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/lib:/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.7/lib /Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.............................................*...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PgAuditLog a model that is audited performance should perform well
     # Temporarily skipped with xit
     # ./spec/pg_audit_log_spec.rb:373


Finished in 1.34 seconds (files took 0.37758 seconds to load)
77 examples, 0 failures, 1 pending

>> BUNDLE_GEMFILE=/Users/arman/Work/pg_audit_log/gemfiles/rails_7_1.gemfile bundle exec rake
/Users/arman/.asdf/installs/ruby/3.3.11/bin/ruby -I/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/lib:/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.7/lib /Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.............................................*...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PgAuditLog a model that is audited performance should perform well
     # Temporarily skipped with xit
     # ./spec/pg_audit_log_spec.rb:373


Finished in 1.38 seconds (files took 0.27626 seconds to load)
77 examples, 0 failures, 1 pending

>> BUNDLE_GEMFILE=/Users/arman/Work/pg_audit_log/gemfiles/rails_7_2.gemfile bundle exec rake
/Users/arman/.asdf/installs/ruby/3.3.11/bin/ruby -I/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/lib:/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.7/lib /Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.............................................*...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PgAuditLog a model that is audited performance should perform well
     # Temporarily skipped with xit
     # ./spec/pg_audit_log_spec.rb:373


Finished in 1.41 seconds (files took 0.27229 seconds to load)
77 examples, 0 failures, 1 pending

>> BUNDLE_GEMFILE=/Users/arman/Work/pg_audit_log/gemfiles/rails_8_0.gemfile bundle exec rake
/Users/arman/.asdf/installs/ruby/3.3.11/bin/ruby -I/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/lib:/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.7/lib /Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.............................................*...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PgAuditLog a model that is audited performance should perform well
     # Temporarily skipped with xit
     # ./spec/pg_audit_log_spec.rb:373


Finished in 1.43 seconds (files took 0.34005 seconds to load)
77 examples, 0 failures, 1 pending

>> BUNDLE_GEMFILE=/Users/arman/Work/pg_audit_log/gemfiles/rails_8_1.gemfile bundle exec rake
/Users/arman/.asdf/installs/ruby/3.3.11/bin/ruby -I/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/lib:/Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-support-3.13.7/lib /Users/arman/.asdf/installs/ruby/3.3.11/lib/ruby/gems/3.3.0/gems/rspec-core-3.13.6/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
.............................................*...............................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) PgAuditLog a model that is audited performance should perform well
     # Temporarily skipped with xit
     # ./spec/pg_audit_log_spec.rb:373


Finished in 1.37 seconds (files took 0.31549 seconds to load)
77 examples, 0 failures, 1 pending
```

It's functionality within `rma` was fully tested in that repo.

## Database or Extract changes

N/A

## Deployment plan

No deployment, this gem will be installed as part of `rma` Rails 8 upgrade PR.

## HIPAA / Security

N/A

## Billing

N/A